### PR TITLE
allow daytona dev origin

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,6 +9,7 @@ const nextConfig = {
       },
     ],
   },
+  allowedDevOrigins: ['*.daytona.work'],
 };
 
 export default nextConfig;


### PR DESCRIPTION
fixes ⚠ Blocked cross-origin request from ***.h1066.daytona.work. To allow this, configure "allowedDevOrigins" in next.config